### PR TITLE
Fix #5008 allow to center on GPS provided location

### DIFF
--- a/app/src/main/res/layout/bottom_container_location_picker.xml
+++ b/app/src/main/res/layout/bottom_container_location_picker.xml
@@ -19,6 +19,22 @@
     app:layout_constraintEnd_toEndOf="parent"
     app:srcCompat="@drawable/ic_check_black_24dp" />
 
+  <com.google.android.material.floatingactionbutton.FloatingActionButton
+    android:id="@+id/current_location_button"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_margin="16dp"
+    android:layout_marginStart="336dp"
+    android:layout_marginBottom="656dp"
+    android:contentDescription="@string/select_location_location_picker"
+    android:tint="@color/achievement_background_dark"
+    app:backgroundTint="@color/white"
+    app:elevation="3dp"
+    app:layout_anchorGravity="top|end"
+    app:layout_constraintTop_toTopOf="parent"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:srcCompat="@drawable/ic_my_location_black_24dp" />
+
   <androidx.appcompat.widget.AppCompatTextView
     android:id="@+id/tv_attribution"
     android:layout_width="wrap_content"
@@ -64,12 +80,12 @@
       android:id="@+id/show_in_map"
       android:layout_width="0dp"
       android:layout_height="wrap_content"
+      android:layout_margin="5dp"
       android:text="@string/show_in_map_app"
       android:textAlignment="center"
       android:textColor="@color/primaryColor"
       android:textSize="14sp"
       android:visibility="gone"
-      android:layout_margin="5dp"
       app:layout_constraintBottom_toBottomOf="@id/map_bottom_layout"
       app:layout_constraintEnd_toEndOf="@id/map_bottom_layout"
       app:layout_constraintStart_toStartOf="@+id/guideline3"


### PR DESCRIPTION
Add center function based on GPS

**Description (required)**

Fixes #5008, add center function based on GPS

What changes did you make and why?

Add a floating button in the map. When the user click this button, the GPS information will be called to obtain the current location of the device and reposition the camera.

**Tests performed (required)**

Tested LocationPickerActivity on Samsung SM-9730 with API level 31.

**Screenshots (for UI changes only)**
![image](https://user-images.githubusercontent.com/91314084/196602577-0aa1eff4-9b32-48b7-95bb-c22b95b5fc59.png)


Need help? See https://support.google.com/android/answer/9075928

---

_Note: Please ensure that you have read CONTRIBUTING.md if this is your first pull request._
