### PR TITLE
update CategoryDetailsActivity

### DIFF
--- a/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.java
+++ b/app/src/main/java/fr/free/nrw/commons/category/CategoryDetailsActivity.java
@@ -2,8 +2,10 @@ package fr.free.nrw.commons.category;
 
 import static fr.free.nrw.commons.category.CategoryClientKt.CATEGORY_PREFIX;
 
+import android.content.ContentValues;
 import android.content.Context;
 import android.content.Intent;
+import android.location.LocationManager;
 import android.net.Uri;
 import android.os.Bundle;
 import android.view.Menu;
@@ -65,7 +67,22 @@ public class CategoryDetailsActivity extends BaseActivity
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         setTabs();
         setPageTitle();
+
+        if (null != savedInstanceState) {
+            categoryName = savedInstanceState.getString("categoryName");
+        }
     }
+
+    /**
+     * Save categoryName
+     * @param outState
+     */
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putString("categoryName", categoryName);
+    }
+
 
     /**
      * This activity contains 3 tabs and a viewpager. This method is used to set the titles of tab,


### PR DESCRIPTION
**Description (required)**

Fixes #the bug that If users view another app, then any work in progress in this app is lost

What changes did you make and why?
Saved category name of images when users leaving, and reloaded the category name of image when users return. After this change, user can see the app state is remain the same as they left and they can continue from where they left.

**Tests performed (required)**
The issue is about switching between common app and other app, unit test is not fit for this issue.



